### PR TITLE
Aggiornate le dipendenze

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "prefer-stable": true,
     "require": {
         "drupal/core-recommended": "^10",
-        "drupal/pathauto": "^1"
+        "drupal/pathauto": "^1",
+        "drupal/color_field": "^3.0"
     }
 }

--- a/lexicum.info.yml
+++ b/lexicum.info.yml
@@ -11,4 +11,4 @@ dependencies:
   - drupal:text
   - drupal:taxonomy
   - drupal:pathauto
-  - color_field:color_field
+  - drupal:color_field


### PR DESCRIPTION
Propongo due fix:
- Ho fixato il nome dell'organizzazione/utente che fornisce la dipendenza `color_field`, presumo che sia il modulo drupal, oppure se è una dipendenza fornita dall'organizzazione `color_field` rifiuta tranquillamente questa PR
- Ho aggiunto color_field come dipendenza, così quando verrà richiesta l'installazione di `urbs-italiae/lexicum` verrà richiesto in automatico `drupal/color_field`